### PR TITLE
User specified hostnames for redirect

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -110,8 +110,14 @@ def login(request,
         came_from = settings.LOGIN_REDIRECT_URL
 
     # Ensure the user-originating redirection url is safe.
-    if not is_safe_url_compat(url=came_from, allowed_hosts={request.get_host()}):
+    # By setting SAML_ALLOWED_HOSTS in settings.py the user may provide a list of "allowed"
+    # hostnames for post-login redirects, much like one would specify ALLOWED_HOSTS .
+    # If this setting is absent, the default is to use the hostname that was used for the current
+    # request.
+    saml_allowed_hosts = set(getattr(settings, 'SAML_ALLOWED_HOSTS', [request.get_host()]))
+    if not is_safe_url_compat(url=came_from, allowed_hosts=saml_allowed_hosts):
         came_from = settings.LOGIN_REDIRECT_URL
+
 
     # if the user is already authenticated that maybe because of two reasons:
     # A) He has this URL in two browser windows and in the other one he


### PR DESCRIPTION
Post-login redirect URL's may often be generated from a client that is accessing an API, however the current implementation only allows redirect urls to point to the same server.  This results in the need for confusing redirect-to-another-route-so-we-can-redirect elsewhere type cases.  This fixes that by allowing the user to list a set of domains that may be redirected to.  The default is to work as it has in the past - so no end user work is needed on upgrading.  However, by specifying a SAML_ALLOWED_HOSTS parameter they can open up the allowable redirect hostnames.